### PR TITLE
ui: Add -o flag to omit static output.

### DIFF
--- a/termio.c
+++ b/termio.c
@@ -167,13 +167,15 @@ termio_init(void)
 		perror("malloc");
 
 	/* Reserve space on terminal */
-	cursor_y = 2;
-	DL_FOREACH(list, t)
-		cursor_y++;
+	cursor_y = 2; /* header */
 #ifdef STATS
 	cursor_y += 7;
 #endif
 	cursor_y += 3; /* legend */
+	if (o_flag)
+		cursor_y = 0;
+	DL_FOREACH(list, t)
+		cursor_y++;
 	scrolldown(cursor_y);
 
 	fprintf(stdout, "%c[7l", 0x1b); /* disable wrapping */
@@ -211,11 +213,13 @@ termio_update(void)
 #endif /* !NCURSES */
 
 	cursor_y = 0;
-	move(cursor_y, 0);
-	clrtoeol();
-	mvprintw(cursor_y, col/2 - (8+strlen(version))/2,
-	    "xping [%s]", version);
-	move(++cursor_y, 0);
+	if (!o_flag) {
+		move(cursor_y, 0);
+		clrtoeol();
+		mvprintw(cursor_y, col/2 - (8+strlen(version))/2,
+				"xping [%s]", version);
+		move(++cursor_y, 0);
+	}
 
 	DL_FOREACH(list, t) {
 		move(++cursor_y, 0);
@@ -238,14 +242,17 @@ termio_update(void)
 			}
 		}
 	}
-	move(++cursor_y, 0);
-	clrtoeol();
-	mvprintw(++cursor_y, 0, "Legend  . echo-reply   ? timeout      # unreach    "
-	    "%%=other");
-	mvprintw(++cursor_y, 0, "        @ resolving    ! send-error");
-	if (C_flag)
-		mvprintw(cursor_y, 38, "%c[2;32mIPv6%c[0m/%c[2;31mIPv4%c[0m",
-		    0x1b, 0x1b, 0x1b, 0x1b);
+	if (!o_flag) {
+		move(++cursor_y, 0);
+		clrtoeol();
+		mvprintw(++cursor_y, 0, "Legend  . echo-reply   ? timeout      # unreach    "
+				"%%=other");
+		mvprintw(++cursor_y, 0, "        @ resolving    ! send-error");
+		if (C_flag)
+			mvprintw(cursor_y, 38, "%c[2;32mIPv6%c[0m/%c[2;31mIPv4%c[0m",
+					0x1b, 0x1b, 0x1b, 0x1b);
+	}
+
 #ifdef STATS
 	cursor_y++;
 	mvprintw(++cursor_y, 0, "Sent: %d", stats->transmitted);

--- a/xping.8
+++ b/xping.8
@@ -51,6 +51,8 @@ Display program usage and exit.
 .It Fl i Ar interval
 Specifies interval between successive packets to a host. Default
 is 1.0 seconds.
+.It Fl o
+Only print out target trace lines. Omit header and legend.
 .El
 .Sh DIAGNOSTICS
 .Bl -tag -width indent

--- a/xping.c
+++ b/xping.c
@@ -31,6 +31,7 @@ int	i_interval = 1000;
 int	a_flag = 0;
 int	A_flag = 0;
 int	C_flag = 0;
+int	o_flag = 0;
 int	T_flag = 0;
 int	v4_flag = 0;
 int	v6_flag = 0;
@@ -539,7 +540,7 @@ usage(const char *whine)
 		fprintf(stderr, "%s\n", whine);
 	}
 	fprintf(stderr,
-	    "usage: xping [-46ACTVah] [-i interval] host [host [...]]\n"
+	    "usage: xping [-46ACTVaho] [-i interval] host [host [...]]\n"
 	    "\n");
 	exit(EX_USAGE);
 }
@@ -576,7 +577,7 @@ main(int argc, char *argv[])
 	}
 
 	/* Parse command line options */
-	while ((ch = getopt(argc, argv, "46ACTai:hV")) != -1) {
+	while ((ch = getopt(argc, argv, "46ACTaoi:hV")) != -1) {
 		switch(ch) {
 		case '4':
 			v4_flag = 1;
@@ -609,6 +610,9 @@ main(int argc, char *argv[])
 			fprintf(stderr, "%s %s (built %s)\n", "xping",
 			    version, built);
 			return (0);
+		case 'o':
+			o_flag = 1;
+			break;
 		case 'h':
 			usage(NULL);
 			/* NOTREACHED */

--- a/xping.h
+++ b/xping.h
@@ -12,6 +12,7 @@
 
 extern struct target *list;
 extern int C_flag;
+extern int o_flag;
 extern int numtargets;
 
 union addr {


### PR DESCRIPTION
If the -o flag is passed, the header and symbol legend are suppressed,
and only the target trace lines are shown in the output.

This does not change the default behaviour.
