### PR TITLE
Provide prototypes for parameterless functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ check-libevent.c:
 	@/bin/echo -n 'Checking for libevent... '; \
 	 (echo '#include <stdio.h>'; \
 	  echo '#include <event2/event.h>'; \
-	  echo 'int main()'; \
+	  echo 'int main(void)'; \
 	  echo '{ printf("%s\\n", event_get_version()); return 0; }' \
 	 ) | $(CC) $(CFLAGS) $(LDFLAGS) -x c -o /dev/null - -levent >/dev/null 2>/dev/null && echo yes || \
 	 (echo no; \
@@ -59,7 +59,7 @@ check-curses.c:
 	@/bin/echo -n 'Checking for libcurses... '; \
 	 (echo '#include <stdio.h>'; \
 	  echo '#include <curses.h>'; \
-	  echo 'int main()'; \
+	  echo 'int main(void)'; \
 	  echo '{ initscr(); return 0; }' \
 	 ) | $(CC) $(CFLAGS) -x c -o /dev/null - -lcurses >/dev/null 2>/dev/null && echo yes || \
 	 (echo no; \
@@ -73,7 +73,7 @@ check-openssl.c:
 	@/bin/echo -n 'Checking for openssl... '; \
 	 (echo '#include <stdio.h>'; \
 	  echo '#include <openssl/ssl.h>'; \
-	  echo 'int main()'; \
+	  echo 'int main(void)'; \
 	  echo '{ printf("%d\\n", SSL_library_init()); return 0; }' \
 	 ) | $(CC) $(CFLAGS) $(LDFLAGS) -x c -o /dev/null - -lssl >/dev/null 2>/dev/null && echo yes || \
 	 (echo no; \

--- a/http.c
+++ b/http.c
@@ -241,7 +241,7 @@ resolved(int af, void *address, void *thunk)
 #define RE_URL 7
 #define RE_MAX 8
 void
-probe_setup()
+probe_setup(void)
 {
 	tv_timeout.tv_sec = 3 * i_interval / 1000;
 	tv_timeout.tv_usec = 3 * i_interval % 1000 * 1000;

--- a/icmp-unpriv.c
+++ b/icmp-unpriv.c
@@ -189,7 +189,7 @@ resolved(int af, void *address, void *thunk)
  *     From 192.0.2.1 icmp_seq=1 Destination Net Unreachable
  */
 void
-probe_setup(struct event_base *parent_event_base)
+probe_setup(void)
 {
 	signal(SIGCHLD, SIG_IGN);
 	if (regcomp(&re_reply,

--- a/icmp.c
+++ b/icmp.c
@@ -376,7 +376,7 @@ resolved(int af, void *address, void *thunk)
  * Prepare datastructures and events needed for probe
  */
 void
-probe_setup()
+probe_setup(void)
 {
 	int i;
 
@@ -407,7 +407,7 @@ probe_setup()
 }
 
 void
-probe_cleanup()
+probe_cleanup(void)
 {
 
 	HASH_CLEAR(hh, hash);

--- a/report.c
+++ b/report.c
@@ -15,7 +15,7 @@
 
 extern int w_width;
 
-void report_init()
+void report_init(void)
 {
 }
 
@@ -23,7 +23,7 @@ void report_update(struct target *t)
 {
 }
 
-void report_cleanup()
+void report_cleanup(void)
 {
 	struct target *t;
 	int i, imax, ifirst, ilast;

--- a/xping.h
+++ b/xping.h
@@ -64,8 +64,8 @@ void report_update(struct target *);
 void report_cleanup(void);
 
 /* from icmp.c */
-void probe_setup();
-void probe_cleanup();
+void probe_setup(void);
+void probe_cleanup(void);
 struct probe *probe_new(const char *, void *);
 void probe_free(struct probe *);
 void probe_send(struct probe *, int);


### PR DESCRIPTION
xping fails to build on modern compiler defaults (clang 15+, gcc 14+), where a function declaration without a prototype is an error under -Werror=strict-prototypes — which the default -Wall -Werror -Wpedantic flags turn on.

This gives the parameterless functions explicit (void) prototypes: probe_setup() and probe_cleanup() in the header and their definitions in icmp.c/http.c, and report_init()/report_cleanup() in report.c (whose header declarations already used (void)). The int main() test programs in the Makefile's configure-time checks get the same treatment, since they otherwise fail the very check they implement.

It also removes the unused struct event_base *parent_event_base parameter from icmp-unpriv.c's probe_setup(). The header declared the function parameterless, the icmp.c and http.c implementations and the lone caller in xping.c all take no argument, and the parameter was never referenced — the absent prototype was the only thing keeping this signature mismatch from being caught.

Built and tested on macOS (Apple clang) with WITH_SSL; no functional change.